### PR TITLE
7.x 1.x soe 3004 footer update

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
 Stanford SOE Regions
 
+Version 7.x-1.0-dev                                                       2018-05-24
+--------------------------------------------------------------------------------
+- Fixing footer to match latest stanford_framework page.tpl.php
+
 Version 7.x-1.0-alpha1                                                    2017-07-11
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #[Stanford SOE Regions](https://github.com/SU-SOE/stanford_soe_regions)
-##### Version: 7.x-1.0-alpha1 
+##### Version: 7.x-1.0-dev
 
 Maintainers: [boznik](https://github.com/boznik)
 

--- a/stanford_soe_regions.info
+++ b/stanford_soe_regions.info
@@ -2,6 +2,6 @@ name = Stanford SOE Regions
 description = Adds regions to SOE.
 core = 7.x
 package = Stanford
-version = 7.x-1.0-alpha1
+version = 7.x-1.0-dev
 project = stanford_soe_regions
 dependencies[] = regions

--- a/templates/digital-magazine-page.tpl.php
+++ b/templates/digital-magazine-page.tpl.php
@@ -23,7 +23,7 @@
       </div>
     </div>
   </div>
-  <!-- /#global-header --> 
+  <!-- /#global-header -->
   <div id="header" class="clearfix header<?php if ($site_title_first_line): ?> line1<?php endif; ?><?php if ($site_title_second_line): ?> line2<?php endif; ?><?php if ($site_title_line3): ?> line3<?php endif; ?><?php if ($site_title_line4): ?> line4 <?php print $site_title_line4_style; ?><?php endif; ?><?php if ($site_title_line5): ?> line5<?php endif; ?>" role="banner">
     <div class="container">
       <div class="row">
@@ -119,7 +119,7 @@
           <div class="container"> <?php print render($page['digital_magazine_megamenu']); ?> </div>
       </div>
   <?php endif; ?>
-  
+
   <?php if ($page['fullwidth_top']): ?>
     <div id="fullwidth-top" class="row-fluid fullwidth">
       <div class="container"> <?php print render($page['fullwidth_top']); ?> </div>
@@ -317,16 +317,16 @@
     <div class="row">
       <div id="bottom-logo" class="span2"><a href="http://www.stanford.edu"><img src="<?php print base_path() . path_to_theme(); ?>/images/footer-stanford-logo@2x.png" alt="Stanford University"></a></div>
       <div id="bottom-menu" class="span10">
-        <ul>
-          <li><a href="http://www.stanford.edu">SU Home</a></li>
-          <li><a href="http://visit.stanford.edu/plan/maps.html">Maps &amp; Directions</a></li>
-          <li><a href="http://www.stanford.edu/search/">Search Stanford</a></li>
-          <li><a href="http://www.stanford.edu/site/terms.html">Terms of Use</a></li>
-          <li><a href="http://emergency.stanford.edu/">Emergency Info</a></li>
-        </ul>
-      </div>
-      <div id="copyright" class="span10 offset2">
-        <p class="vcard">&copy; <span class="fn org">Stanford University</span>, <span class="adr"><span class="locality">Stanford</span>, <span class="region">California</span> <span class="postal-code">94305</span></span>. <span class="copyright-links"><a href="http://www.stanford.edu/site/copyright.html">Copyright Complaints</a></span></p>
+
+        <?php foreach ($stanford_links as $class => $link_group): ?>
+          <ul class="<?php print $class; ?> clearfix">
+            <?php foreach ($link_group as $link): ?>
+              <li><?php print $link; ?></li>
+            <?php endforeach ?>
+          </ul>
+        <?php endforeach ?>
+
+        <p class="vcard">&copy; <span class="fn org">Stanford University</span>, <span class="adr"><span class="locality">Stanford</span>, <span class="region">California</span> <span class="postal-code">94305</span></span>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
This adds the updated footer markup from the stanford_framework theme update.

# Needed By (Date)
- Sprint end

# Criticality
- Needed by COB Friday May 25, 2018


# Steps to Test
- Switch to this branch  -  `7.x-1.x-SOE-3004-footer-update` (https://github.com/SU-SOE/stanford_soe_helper/tree/7.x-1.x-SOE-3004-footer-update)
- It should look like this: https://anthropology-uat.stanford.edu/

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-3004

## Related PRs

## More Information

## Folks to notify
@boznik 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)